### PR TITLE
[DataLayer] Prepare beta version of the Adobe Client Data Layer

### DIFF
--- a/src/tests/DataLayer.test.js
+++ b/src/tests/DataLayer.test.js
@@ -7,9 +7,8 @@ of the License at http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
-governing pefrmissions and limitations under the License.
+governing permissions and limitations under the License.
 */
-'use strict';
 const DataLayer = require('../scripts/DataLayer');
 let dataLayer;
 
@@ -659,23 +658,4 @@ test.skip('high load', () => {
     expect(mockCallback.mock.calls.length).toBe(i + 1);
   }
 
-});
-
-// -----------------------------------------------------------------------------------------------------------------
-// DataLayer.utils functions
-// -----------------------------------------------------------------------------------------------------------------
-
-test('deep merge of target and source object', () => {
-  let target = {
-    a: {
-      ab: 12
-    }
-  };
-  DataLayer.utils.deepMerge(target, { a: { ab: undefined, ac: 13, ad: { ada: 141 } }, b: 2 });
-  expect(target).toMatchObject({ a: { ac: 13, ad: { ada: 141 } }, b: 2 });
-});
-
-test('argument to be an object', () => {
-  expect(DataLayer.utils.isObject({ foo: 'bar' })).toBe(true);
-  expect(DataLayer.utils.isObject(['foo', 'bar'])).toBe(false);
 });

--- a/src/tests/DataLayerUtils.test.js
+++ b/src/tests/DataLayerUtils.test.js
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const DataLayer = require('../scripts/DataLayer');
+
+describe('DataLayerUtils', () => {
+  describe('deepMerge()', () => {
+    test('source and target objects are deep merged', () => {
+      let target = {
+        a: {
+          aa: 12
+        }
+      };
+      let source = {
+        a: {
+          aa: 13,
+          ab: {
+            aba: 141
+          }
+        },
+        b: 2
+      };
+      let expected = {
+        a: {
+          aa: 13,
+          ab: {
+            aba: 141
+          }
+        },
+        b: 2
+      };
+      DataLayer.utils.deepMerge(target, source);
+      expect(target).toMatchObject(expected);
+    });
+    test('undefined keys are removed', () => {
+      let target = {
+        a: 12
+      };
+      let source = {
+        a: undefined
+      };
+      let expected = {};
+      DataLayer.utils.deepMerge(target, source);
+      expect(target).toMatchObject(expected);
+    });
+  });
+
+  describe('isObject()', () => {
+    test('Object argument is an object', () => {
+      expect(DataLayer.utils.isObject({ foo: 'bar' })).toBe(true);
+    });
+    test('Array argument is not an object', () => {
+      expect(DataLayer.utils.isObject(['foo', 'bar'])).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- moves DataLayerUtils tests to own file and adds test suites.
- fixes copyright statement
- removes use strict from test suite