### PR TITLE
Add a path argument to dataLayer.getState()

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Adobe Data Layer | Examples</title>
-    <script>dataLayer = [];</script>
+    <script>adobeDataLayer = [];</script>
     <script src="../dist/adobe-client-data-layer.min.js" async></script>
     <script src="js/datalayer.mocks.1.js" defer></script>
 </head>

--- a/src/scripts/DataLayer.js
+++ b/src/scripts/DataLayer.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 /* eslint no-console: "off" */
 const mergeWith = require('lodash.mergewith');
 const cloneDeep = require('lodash.clonedeep');
+const get = require('lodash.get');
 
 /**
  * Data Layer.
@@ -165,7 +166,10 @@ DataLayer.Manager.prototype._augment = function() {
    *
    * @returns {Object} The deep copied state object.
    */
-  that._dataLayer.getState = function() {
+  that._dataLayer.getState = function(path) {
+    if (path) {
+      return get(cloneDeep(that._state), path);
+    }
     return cloneDeep(that._state);
   };
 };
@@ -262,7 +266,7 @@ DataLayer.Manager.prototype._processItem = function(item) {
 };
 
 new DataLayer.Manager({
-  dataLayer: window.dataLayer
+  dataLayer: window.adobeDataLayer
 });
 
 /**

--- a/src/tests/DataLayer.test.js
+++ b/src/tests/DataLayer.test.js
@@ -870,6 +870,28 @@ test('invalid item is filtered out from array', () => {
 });
 
 // -----------------------------------------------------------------------------------------------------------------
+// getState()
+// -----------------------------------------------------------------------------------------------------------------
+
+test('getState()', () => {
+  const carousel1 = {
+    id: '/content/mysite/en/home/jcr:content/root/carousel1',
+    items: {}
+  };
+  const data = {
+    component: {
+      carousel: {
+        carousel1: carousel1
+      }
+    }
+  };
+  dataLayer.push({ data: data });
+  expect(dataLayer.getState()).toStrictEqual(data);
+  expect(dataLayer.getState("component.carousel.carousel1")).toStrictEqual(carousel1);
+  expect(dataLayer.getState("undefined-path")).toStrictEqual(undefined);
+});
+
+// -----------------------------------------------------------------------------------------------------------------
 // Performance
 // -----------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
- add a path argument
- rename the data layer object adobeDataLayer
