### PR TITLE
npm scripts as an interface for gulp tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,13 @@ This script can then be included in your page head, as follows:
 
 First run the following commands:
 ```
-npm install -g gulp-cli
 npm install
 ```   
  
-Then choose from the following gulp tasks:
-* `gulp` - run the tests, generates the build in the `./dist` folder and runs a development server on `localhost:3000`.
-* `gulp build` - run the tests and generates the build in the `./dist` folder.
-* `gulp test` - run the unit tests
+Then choose from the following npm scripts:
+* `npm run dev` - run the tests, generates the build in the `./dist` folder and runs a development server on `localhost:3000`.
+* `npm run build` - run the tests and generates the build in the `./dist` folder.
+* `npm run test` - run the unit tests
 
 ## Releasing
 
@@ -48,7 +47,7 @@ rm -rf node_modules && npm install
 ```
 
 Then run:
-* `gulp release` - prompts for a new version, with patch, minor or major versions allowed, see [NPM Semantic Versioning](https://docs.npmjs.com/about-semantic-versioning).
+* `npm run release` - prompts for a new version, with patch, minor or major versions allowed, see [NPM Semantic Versioning](https://docs.npmjs.com/about-semantic-versioning).
   Following selection, the task will increase, commit and push the version, create and push the Git release tag, and publish the npm package.
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "license": "Apache-2.0",
   "private": false,
   "homepage": "https://github.com/adobe/adobe-client-data-layer#readme",
+  "scripts": {
+    "build": "gulp build",
+    "dev": "gulp",
+    "release": "gulp release",
+    "test": "gulp test"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/adobe-client-data-layer"


### PR DESCRIPTION
Right now for the dev / build / release process we use gulp. We should add npm scripts which would trigger gulp tasks.

Why?

1. If you run your gulp task with `npm script` you do not need `gulp-cli` installed on your computer. That is good for not requiring additional global `npm install` on a developer.
2. It helps with avoiding gulp versions mismatch. When I installed `gulp-cli` globally you can get a version that was not compatible with version of `gulp` used in project. I had 2 options:
- reinstall with proper version (use proper node version)
- run `gulp` using local instance `node ./node_modules/gulp/bin/gulp.js`. When you use `gulp` inside of `npm script` it calls the local version of gulp first.
3. We get a unified interface for our tools. We do not have to expose our tools in the first place. Secondly we can exchange the build process behind the scenes without changing npm interface for build/release.