### PR TITLE
Increase code coverage

### DIFF
--- a/src/utils/customMerge.js
+++ b/src/utils/customMerge.js
@@ -27,10 +27,6 @@ const isNull = _.isNull;
  * @private
  */
 module.exports = function(object, source) {
-  const omitDeep = function(value, predicate = (val) => !val) {
-    return cloneDeepWith(value, makeOmittingCloneDeepCustomizer(predicate));
-  };
-
   const makeOmittingCloneDeepCustomizer = function(predicate) {
     return function omittingCloneDeepCustomizer(value, key, object, stack) {
       if (isObject(value)) {
@@ -54,6 +50,10 @@ module.exports = function(object, source) {
     if (typeof srcValue === 'undefined' || srcValue === null) {
       return null;
     }
+  };
+
+  const omitDeep = function(value, predicate = (val) => !val) {
+    return cloneDeepWith(value, makeOmittingCloneDeepCustomizer(predicate));
   };
 
   mergeWith(object, source, customizer);

--- a/src/utils/dataMatchesContraints.js
+++ b/src/utils/dataMatchesContraints.js
@@ -19,6 +19,12 @@ module.exports = function(data, constraints) {
     const valueType = typeof value;
     if (mandatory) {
       return !value || valueType !== type || (supportedValues && !supportedValues.includes(value));
+    } else {
+      if (value) {
+        return valueType !== type || (supportedValues && !supportedValues.includes(value));
+      } else {
+        return false;
+      }
     }
   }) === 'undefined';
 };

--- a/src/utils/dataMatchesContraints.js
+++ b/src/utils/dataMatchesContraints.js
@@ -20,11 +20,7 @@ module.exports = function(data, constraints) {
     if (mandatory) {
       return !value || valueType !== type || (supportedValues && !supportedValues.includes(value));
     } else {
-      if (value) {
-        return valueType !== type || (supportedValues && !supportedValues.includes(value));
-      } else {
-        return false;
-      }
+      return value && (valueType !== type || (supportedValues && !supportedValues.includes(value)));
     }
   }) === 'undefined';
 };


### PR DESCRIPTION
Fixes https://github.com/adobe/adobe-client-data-layer/issues/78

Increases code coverage as follows:

```
---------------------------|----------|----------|----------|----------|-------------------|
File                       |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
---------------------------|----------|----------|----------|----------|-------------------|
All files                  |    99.62 |    99.26 |    97.87 |      100 |                   |
 src                       |      100 |      100 |      100 |      100 |                   |
  constants.js             |      100 |      100 |      100 |      100 |                   |
  dataLayerManager.js      |      100 |      100 |      100 |      100 |                   |
  index.js                 |      100 |      100 |      100 |      100 |                   |
  item.js                  |      100 |      100 |      100 |      100 |                   |
  itemConstraints.js       |      100 |      100 |      100 |      100 |                   |
  listener.js              |      100 |      100 |      100 |      100 |                   |
  listenerManager.js       |      100 |      100 |      100 |      100 |                   |
 src/utils                 |    98.78 |    98.08 |    92.31 |      100 |                   |
  ancestorRemoved.js       |      100 |      100 |      100 |      100 |                   |
  customMerge.js           |    96.55 |    90.91 |    85.71 |      100 |                55 |
  dataMatchesContraints.js |      100 |      100 |      100 |      100 |                   |
  indexOfListener.js       |      100 |      100 |      100 |      100 |                   |
  listenerMatch.js         |      100 |      100 |      100 |      100 |                   |
---------------------------|----------|----------|----------|----------|-------------------|

```