### PR TITLE
Incorrect before state event parameter for past events

### DIFF
--- a/src/dataLayerManager.js
+++ b/src/dataLayerManager.js
@@ -99,6 +99,10 @@ module.exports = function(config) {
       const filteredArguments = arguments;
 
       Object.keys(pushArguments).forEach(function(key) {
+        const _internalState = cloneDeep(_state);
+        delete _internalState._state;
+        pushArguments[key]._state = _internalState;
+
         const itemConfig = pushArguments[key];
         const item = Item(itemConfig);
 

--- a/src/listenerManager.js
+++ b/src/listenerManager.js
@@ -18,7 +18,7 @@ const constants = require('./constants');
 const listenerMatch = require('./utils/listenerMatch');
 const indexOfListener = require('./utils/indexOfListener');
 const customMerge = require('./utils/customMerge');
-const Item = require('./item');
+// const Item = require('./item');
 
 /**
  * Creates a listener manager.
@@ -146,6 +146,7 @@ module.exports = function(dataLayerManager) {
 
   function _getStates(item) {
     const _state = {};
+    /*
     const _dataLayer = _dataLayerManager.getDataLayer();
     for (let i = 0; i < item.index; i++) {
       const _item = Item(_dataLayer[i]);
@@ -153,8 +154,9 @@ module.exports = function(dataLayerManager) {
         customMerge(_state, _item.data);
       }
     }
-    const _beforeState = cloneDeep(_state);
-    const _afterState = customMerge(_state, item.data);
+     */
+    const _beforeState = cloneDeep(item.config._state);
+    const _afterState = customMerge(item.config._state, item.data);
     return {
       before: _beforeState,
       after: _afterState


### PR DESCRIPTION
POC: this is an alternate way of fixing #96 introduced in PR #104.

We keep a copy of the state for each item.
It reduces the cost of processing the before/after states as the state at the time we push an item can be read from an item property.
But it increases the memory footprint as it is keeping all the past states.