### PR TITLE
IE11 fix using lodash .find (#106)

### DIFF
--- a/gulp/tasks/lodash.js
+++ b/gulp/tasks/lodash.js
@@ -13,7 +13,7 @@ module.exports = function(gulp) {
   const shell = require('gulp-shell');
 
   const configs = {
-    include: ['cloneDeep', 'cloneDeepWith', 'get', 'has', 'isEmpty', 'isEqual', 'isNull', 'isPlainObject', 'isObject', 'merge', 'mergeWith', 'omit', 'reject'],
+    include: ['cloneDeep', 'cloneDeepWith', 'get', 'has', 'isEmpty', 'isEqual', 'isNull', 'isPlainObject', 'isObject', 'merge', 'mergeWith', 'omit', 'reject', 'find'],
     output: 'custom-lodash.js'
   };
 

--- a/src/item.js
+++ b/src/item.js
@@ -14,6 +14,7 @@ const _ = require('../custom-lodash');
 const isPlainObject = _.isPlainObject;
 const isEmpty = _.isEmpty;
 const omit = _.omit;
+const find = _.find;
 
 const dataMatchesContraints = require('./utils/dataMatchesContraints');
 const ITEM_CONSTRAINTS = require('./itemConstraints');
@@ -34,7 +35,7 @@ module.exports = function(itemConfig, index) {
   const _valid = !!_type;
 
   function getType() {
-    return Object.keys(ITEM_CONSTRAINTS).find(key => dataMatchesContraints(_config, ITEM_CONSTRAINTS[key])) ||
+    return find(Object.keys(ITEM_CONSTRAINTS), key => dataMatchesContraints(_config, ITEM_CONSTRAINTS[key])) ||
       (typeof _config === 'function' && CONSTANTS.itemType.FCTN) ||
       (isPlainObject(_config) && CONSTANTS.itemType.DATA);
   }

--- a/src/utils/dataMatchesContraints.js
+++ b/src/utils/dataMatchesContraints.js
@@ -10,9 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const _ = require('../../custom-lodash');
+const find = _.find;
+
 module.exports = function(data, constraints) {
   // Go through all constraints and find one which does not match the data
-  const foundObjection = Object.keys(constraints).find(key => {
+  const foundObjection = find(Object.keys(constraints), key => {
     const type = constraints[key].type;
     const supportedValues = key && constraints[key].values;
     const mandatory = !constraints[key].optional;


### PR DESCRIPTION
IE11 Fix

## Description

Fix for IE11 not supporting `.find` method on arrays. Fix provides replacement with `.find` method from lodash collection.

Extended dependency increases size of ACDL from `31 325 B` to `32 307 B`.

## Related Issue

Fixes #106 
