### PR TITLE
IE11 includes bugfix

### DIFF
--- a/gulp/tasks/lodash.js
+++ b/gulp/tasks/lodash.js
@@ -13,7 +13,7 @@ module.exports = function(gulp) {
   const shell = require('gulp-shell');
 
   const configs = {
-    include: ['cloneDeep', 'cloneDeepWith', 'get', 'has', 'isEmpty', 'isEqual', 'isNull', 'isPlainObject', 'isObject', 'merge', 'mergeWith', 'omit', 'reject', 'find'],
+    include: ['cloneDeep', 'cloneDeepWith', 'find', 'get', 'has', 'includes', 'isEmpty', 'isEqual', 'isNull', 'isPlainObject', 'isObject', 'merge', 'mergeWith', 'omit', 'reject'],
     output: 'custom-lodash.js'
   };
 

--- a/src/utils/dataMatchesContraints.js
+++ b/src/utils/dataMatchesContraints.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 const _ = require('../../custom-lodash');
 const find = _.find;
+const includes = _.includes;
 
 module.exports = function(data, constraints) {
   // Go through all constraints and find one which does not match the data
@@ -22,7 +23,7 @@ module.exports = function(data, constraints) {
     const value = data[key];
     const valueType = typeof value;
     const incorrectType = type && valueType !== type;
-    const noMatchForSupportedValues = supportedValues && !supportedValues.includes(value);
+    const noMatchForSupportedValues = supportedValues && !includes(supportedValues, value);
     if (mandatory) {
       return !value || incorrectType || noMatchForSupportedValues;
     } else {


### PR DESCRIPTION
Fixes `includes` error in IE11.

Fixes #106 

Increases size of the ACDL from `32 307 B ` to `32 809 B`.