### PR TITLE
GH-96 - Incorrect before state event parameter for past events

### DIFF
--- a/src/__tests__/demo.js
+++ b/src/__tests__/demo.js
@@ -116,12 +116,10 @@ window.adobeDataLayer.push({
   }
 });
 
-const fct2 = function(event, oldState, newState) {
+const fct2 = function(event) {
   console.log('fct2');
   console.log('this', this);
   console.log('event', event);
-  console.log('oldState', oldState);
-  console.log('newState', newState);
 };
 
 window.adobeDataLayer.addEventListener('adobeDataLayer:change', fct2, { scope: 'future' });
@@ -141,12 +139,10 @@ window.adobeDataLayer.push({
 // Adding an event listener: path
 // -----------------------------------------------------------------------------------------------------------------
 
-const fct3 = function(event, oldValue, newValue) {
+const fct3 = function(event) {
   console.log('fct3');
   console.log('this', this);
   console.log('event', event);
-  console.log('oldValue', oldValue);
-  console.log('newValue', newValue);
 };
 
 window.adobeDataLayer.addEventListener('adobeDataLayer:change', fct3, { path: 'component.carousel.carousel5' });

--- a/src/__tests__/scenarios/events.test.js
+++ b/src/__tests__/scenarios/events.test.js
@@ -42,7 +42,7 @@ describe('Events', () => {
     expect(calls, 'just one argument if no data is added').toStrictEqual(1);
 
     adobeDataLayer.push({ event: 'test', somekey: 'somedata' });
-    expect(calls, 'three arguments if data is added').toStrictEqual(3);
+    expect(calls, 'just one argument if data is added').toStrictEqual(1);
   });
 
   test('check if eventInfo is passed to callback', () => {

--- a/src/__tests__/scenarios/listeners.test.js
+++ b/src/__tests__/scenarios/listeners.test.js
@@ -9,9 +9,6 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-const isEqual = require('lodash/isEqual');
-const merge = require('lodash/merge');
-
 const testData = require('../testData');
 const DataLayerManager = require('../../dataLayerManager');
 const DataLayer = { Manager: DataLayerManager };
@@ -242,54 +239,6 @@ describe('Event listeners', () => {
       adobeDataLayer.addEventListener('adobeDataLayer:change', mockCallback, { path: 'component' });
       adobeDataLayer.push(testData.image1change);
       expect(mockCallback.mock.calls.length).toBe(3);
-    });
-
-    test('old / new value', () => {
-      const compareOldNewValueFunction = function(event, oldValue, newValue) {
-        if (oldValue === 'old') mockCallback();
-        if (newValue === 'new') mockCallback();
-      };
-
-      adobeDataLayer.push(testData.carousel1oldId);
-      adobeDataLayer.addEventListener('adobeDataLayer:change', compareOldNewValueFunction, {
-        path: 'component.carousel.carousel1.id'
-      });
-      adobeDataLayer.push(testData.carousel1newId);
-      expect(mockCallback.mock.calls.length).toBe(2);
-    });
-
-    test('old / new state', () => {
-      const compareOldNewStateFunction = function(event, oldState, newState) {
-        if (isEqual(oldState, testData.carousel1oldId)) mockCallback();
-        if (isEqual(newState, testData.carousel1newId)) mockCallback();
-      };
-
-      adobeDataLayer.push(merge({ event: 'adobeDataLayer:change' }, testData.carousel1oldId));
-      adobeDataLayer.addEventListener('adobeDataLayer:change', compareOldNewStateFunction);
-      adobeDataLayer.push(merge({ event: 'adobeDataLayer:change' }, testData.carousel1newId));
-      expect(mockCallback.mock.calls.length).toBe(2);
-    });
-
-    test('calling getState() within a handler should return the state after the event', () => {
-      const compareGetStateWithNewStateFunction = function(event, oldState, newState) {
-        if (isEqual(this.getState(), newState)) mockCallback();
-      };
-
-      adobeDataLayer.push(merge({ event: 'adobeDataLayer:change' }, testData.carousel1oldId));
-      adobeDataLayer.addEventListener('adobeDataLayer:change', compareGetStateWithNewStateFunction);
-      adobeDataLayer.push(merge({ event: 'adobeDataLayer:change' }, testData.carousel1oldId));
-      expect(mockCallback.mock.calls.length).toBe(1);
-    });
-
-    test('undefined old / new state for past events', () => {
-      // this behaviour is explained at: https://github.com/adobe/adobe-client-data-layer/issues/33
-      const isOldNewStateUndefinedFunction = function(event, oldState, newState) {
-        if (isEqual(oldState, undefined) && isEqual(newState, undefined)) mockCallback();
-      };
-
-      adobeDataLayer.push(testData.carousel1change);
-      adobeDataLayer.addEventListener('adobeDataLayer:change', isOldNewStateUndefinedFunction, { scope: 'past' });
-      expect(mockCallback.mock.calls.length).toBe(1);
     });
   });
 

--- a/src/dataLayerManager.js
+++ b/src/dataLayerManager.js
@@ -33,7 +33,6 @@ module.exports = function(config) {
   let _dataLayer = [];
   let _preLoadedItems = [];
   let _state = {};
-  let _previousStateCopy = {};
   let _listenerManager;
 
   const DataLayerManager = {
@@ -42,9 +41,6 @@ module.exports = function(config) {
     },
     getDataLayer: function() {
       return _dataLayer;
-    },
-    getPreviousState: function() {
-      return _previousStateCopy;
     }
   };
 
@@ -67,7 +63,6 @@ module.exports = function(config) {
     _dataLayer = _config.dataLayer;
     _dataLayer.version = version;
     _state = {};
-    _previousStateCopy = {};
     _listenerManager = ListenerManager(DataLayerManager);
   };
 
@@ -78,7 +73,6 @@ module.exports = function(config) {
    * @private
    */
   function _updateState(item) {
-    _previousStateCopy = cloneDeep(_state);
     _state = customMerge(_state, item.data);
   };
 
@@ -148,12 +142,6 @@ module.exports = function(config) {
      * @callback eventListenerCallback A function that is called when the event of the specified type occurs.
      * @this {DataLayer}
      * @param {Object} event The event object pushed to the data layer that triggered the callback.
-     * @param {Object} [beforeState] The state before the change caused by the event. Available only when the event
-     * object has data that modify the state. If a path filter option has been provided when registering the event,
-     * the object will only contain the data at the defined path.
-     * @param {Object} [afterState] The state after the change caused by the event. Available only when the event
-     * object has data that modify the state. If a path filter option has been provided when registering the event,
-     * the object will only contain the data at the defined path.
      */
 
     /**

--- a/src/listenerManager.js
+++ b/src/listenerManager.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 const _ = require('../custom-lodash');
 const cloneDeep = _.cloneDeep;
-const get = _.get;
 
 const constants = require('./constants');
 const listenerMatch = require('./utils/listenerMatch');
@@ -86,7 +85,7 @@ module.exports = function(dataLayerManager) {
       triggeredEvents.forEach(function(event) {
         if (Object.prototype.hasOwnProperty.call(_listeners, event)) {
           for (const listener of _listeners[event]) {
-            _callHandler(listener, item, false);
+            _callHandler(listener, item);
           }
         }
       });
@@ -99,7 +98,7 @@ module.exports = function(dataLayerManager) {
      * @param {Item} item Item to call the listener with.
      */
     triggerListener: function(listener, item) {
-      _callHandler(listener, item, true);
+      _callHandler(listener, item);
     }
   };
 
@@ -108,25 +107,11 @@ module.exports = function(dataLayerManager) {
    *
    * @param {Listener} listener The listener.
    * @param {Item} item The item.
-   * @param {Boolean} isPastItem Flag indicating whether the item was registered before the listener.
    * @private
    */
-  function _callHandler(listener, item, isPastItem) {
+  function _callHandler(listener, item) {
     if (listenerMatch(listener, item)) {
       const callbackArgs = [cloneDeep(item.config)];
-
-      if (item.data) {
-        if (listener.path) {
-          const oldValue = get(_dataLayerManager.getPreviousState(), listener.path);
-          const newValue = get(cloneDeep(item.data), listener.path);
-          callbackArgs.push(oldValue, newValue);
-        } else if (!isPastItem) {
-          const oldState = _dataLayerManager.getPreviousState();
-          const newState = cloneDeep(_dataLayerManager.getState());
-          callbackArgs.push(oldState, newState);
-        }
-      }
-
       listener.handler.apply(_dataLayerManager.getDataLayer(), callbackArgs);
     }
   }


### PR DESCRIPTION
- remove the before and after states arguments from the event listener callbacks
- adapt tests

fixes ticket #96 
