### PR TITLE
bug: duplicate initialization drops existing listeners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,16 @@ const DataLayer = {
 
 window.adobeDataLayer = window.adobeDataLayer || [];
 
-DataLayer.Manager({
-  dataLayer: window.adobeDataLayer
-});
+// If data layer has already been initialized, do not re-initialize.
+if (window.adobeDataLayer.version) {
+  console.warn(
+    `Adobe Client Data Layer v${window.adobeDataLayer.version} has already been imported/initialized on this page. You may be erroneously loading it a second time.`
+  );
+} else {
+  DataLayer.Manager({
+    dataLayer: window.adobeDataLayer,
+  });
+}
 
 /**
  * @typedef  {Object} ListenerOnConfig


### PR DESCRIPTION
## Description

Rather than try to gracefully merge an existing acdl (post-augment) with one loaded later, I simply check for an existing property and, if it exists, skip initialization entirely.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #126 

## Motivation and Context

See #126 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using the [sandbox](https://codesandbox.io/s/acdl-6uo2x) from the issue, I proxied the unpkg import to a local built file that included the changes in this PR. 

Doing so logged the warning and allowed the second event to be observed by the original listener without having to re-attach it.

 See screenshot below.

## Screenshots (if appropriate):

[![Image from Gyazo](https://i.gyazo.com/d7ce5f5136bfe9f370fd2e038c143597.png)](https://gyazo.com/d7ce5f5136bfe9f370fd2e038c143597)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
